### PR TITLE
Check for the remote to be set before attempting to remove it.

### DIFF
--- a/Assets/Wiimote/Scripts/WiimoteManager.cs
+++ b/Assets/Wiimote/Scripts/WiimoteManager.cs
@@ -117,10 +117,13 @@ public class WiimoteManager
     /// \param remote The remote to cleanup
     public static void Cleanup(Wiimote remote)
     {
-        if (remote.hidapi_handle != IntPtr.Zero)
-            HIDapi.hid_close(remote.hidapi_handle);
+        if (remote != null)
+		{
+			if (remote.hidapi_handle != IntPtr.Zero)
+				HIDapi.hid_close (remote.hidapi_handle);
 
-        Wiimotes.Remove(remote);
+			Wiimotes.Remove (remote);
+		}
     }
 
     /// \return If any Wii Remotes are connected and found by FindWiimote


### PR DESCRIPTION
This should handle this issue https://github.com/Flafla2/Unity-Wiimote/issues/7
